### PR TITLE
Update gitattributes for ZIP archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
-*.zip filter=lfs diff=lfs merge=lfs -text
+# Treat ZIP archives as binary and store them in Git LFS
+*.[zZ][iI][pP] filter=lfs diff=lfs merge=lfs -text
 *.tar.gz filter=lfs diff=lfs merge=lfs -text
 *.tgz filter=lfs diff=lfs merge=lfs -text
 *.7z filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary
- improve ZIP archive handling in `.gitattributes` so extensions are matched case-insensitively

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68712cfce6c0832694e34415bc116619